### PR TITLE
add verify_email configuration option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 composer.phar
 composer.lock
 .DS_Store
+.idea
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 php:
   - 5.5
   - 5.6
-  - hhvm
 
 before_script:
   - travis_retry composer self-update

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+### 1.0.2
+
+* make email_verified check optional
+
 ### 1.0.1
 
 * add email_verified check

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ if (!isset($_GET['code'])) {
 }
 ```
 
+By default Intercom provider rejects users with unverified email addresses. User info will not be populated in that case. To disable this check add verifyEmail set to false to your config:
+
+```php
+$provider = new Intercom\OAuth2\Client\Provider\Intercom([
+    'clientId'          => '{intercom-client-id}',
+    'clientSecret'      => '{intercom-client-secret}',
+    'redirectUri'       => 'https://example.com/callback-url',
+    'verifyEmail'       => false
+]);
+```
 
 ## Refreshing a Token
 

--- a/src/Provider/Intercom.php
+++ b/src/Provider/Intercom.php
@@ -9,6 +9,12 @@ use Psr\Http\Message\ResponseInterface;
 
 class Intercom extends AbstractProvider
 {
+
+    /**
+     * @var boolean By default Intercom strategy rejects users with unverified email addresses.
+     */
+    protected $verifyEmail = true;
+
     /**
      * Get authorization url to begin OAuth flow
      *
@@ -80,7 +86,7 @@ class Intercom extends AbstractProvider
      */
     protected function getDefaultHeaders()
     {
-        return [ 'Accept' => 'application/json', 'User-Agent' => 'league/oauth2-intercom/1.0.1' ];
+        return [ 'Accept' => 'application/json', 'User-Agent' => 'league/oauth2-intercom/1.0.2' ];
     }
 
 
@@ -119,6 +125,10 @@ class Intercom extends AbstractProvider
      */
     protected function createResourceOwner(array $response, AccessToken $token)
     {
-        return new IntercomResourceOwner($response);
+        $validatedResponse = $response;
+        if ($this->verifyEmail == true && $response['email_verified'] != true) {
+            $validatedResponse = [];
+        }
+        return new IntercomResourceOwner($validatedResponse);
     }
 }

--- a/src/Provider/IntercomResourceOwner.php
+++ b/src/Provider/IntercomResourceOwner.php
@@ -20,11 +20,7 @@ class IntercomResourceOwner implements ResourceOwnerInterface
      */
     public function __construct(array $response = array())
     {
-        if ($response['email_verified'] == true) {
-            $this->response = $response;
-        } else {
-            $this->response = array();
-        }
+        $this->response = $response;
     }
 
     /**

--- a/tests/src/Provider/IntercomTest.php
+++ b/tests/src/Provider/IntercomTest.php
@@ -139,6 +139,45 @@ class IntercomTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(null, $user->getAvatarUrl());
     }
 
+    public function testSkipUserUnverifiedEmailCheck()
+    {
+        $provider = new \Intercom\OAuth2\Client\Provider\Intercom([
+            'clientId' => 'mock_client_id',
+            'clientSecret' => 'mock_secret',
+            'redirectUri' => 'none',
+            'verifyEmail' => false
+        ]);
+
+        $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
+
+        $postResponse->shouldReceive('getBody')->andReturn('{"token": "mock_access_token", "access_token": "mock_access_token", "token_type": "Bearer"}');
+        $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $postResponse->shouldReceive('getStatusCode')->andReturn(200);
+
+        $userJson = '{"type":"admin","id":"368312","email":"fizbit@intercom.io","name":"Fizbit Grappleboot","email_verified":false,"app":{"type":"app","id_code":"2qmk5gy1","created_at":1358214715,"secure":true},"avatar":{"type":"avatar", "image_url":"https://static.intercomassets.com/avatars/228311/square_128/1462489937.jpg"}}';
+        $userArray = json_decode($userJson, true);
+
+        $userResponse = m::mock('Psr\Http\Message\ResponseInterface');
+        $userResponse->shouldReceive('getBody')->andReturn($userJson);
+        $userResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $userResponse->shouldReceive('getStatusCode')->andReturn(200);
+
+        $client = m::mock('GuzzleHttp\ClientInterface');
+        $client->shouldReceive('send')
+            ->times(2)
+            ->andReturn($postResponse, $userResponse);
+        $provider->setHttpClient($client);
+
+        $token = $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $user = $provider->getResourceOwner($token);
+
+        $this->assertEquals($userArray, $user->toArray());
+        $this->assertEquals($userArray['id'], $user->getId());
+        $this->assertEquals($userArray['email'], $user->getEmail());
+        $this->assertEquals($userArray['name'], $user->getName());
+        $this->assertEquals($userArray['avatar']['image_url'], $user->getAvatarUrl());
+    }
+
     /**
      * @expectedException League\OAuth2\Client\Provider\Exception\IdentityProviderException
      **/


### PR DESCRIPTION
By default Intercom provider rejects users with unverified email addresses. User info will not be populated in that case. This adds optional param to disable the check.