### PR TITLE
Upgrade to league/oauth2-client and add support for PHP 7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
   - travis_retry composer self-update

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+### 2.0.0
+
+* Upgrade to `league/oauth2-client` 2.3+. Please read the [changelog](https://github.com/thephpleague/oauth2-client/blob/master/CHANGELOG.md#200) regarding the library's breaking changes
+* Added support for PHP 7.0, 7.1 and 7.2
+* Removed support for PHP 5.5 (EOL)
+
 ### 1.0.2
 
 * make email_verified check optional

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "intercom"
     ],
     "require": {
-        "php": ">=5.5.0",
-        "league/oauth2-client": "~1.0"
+        "php": "^5.6|^7.0",
+        "league/oauth2-client": "~2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/src/Provider/Intercom.php
+++ b/src/Provider/Intercom.php
@@ -86,7 +86,7 @@ class Intercom extends AbstractProvider
      */
     protected function getDefaultHeaders()
     {
-        return [ 'Accept' => 'application/json', 'User-Agent' => 'league/oauth2-intercom/1.0.2' ];
+        return [ 'Accept' => 'application/json', 'User-Agent' => 'league/oauth2-intercom/2.0.0' ];
     }
 
 

--- a/src/Provider/Intercom.php
+++ b/src/Provider/Intercom.php
@@ -113,7 +113,7 @@ class Intercom extends AbstractProvider
 
         $request = $this->getAuthenticatedRequest(self::METHOD_GET, $url, $token);
 
-        return $this->getResponse($request);
+        return $this->getParsedResponse($request);
     }
 
     /**

--- a/tests/src/Provider/IntercomTest.php
+++ b/tests/src/Provider/IntercomTest.php
@@ -185,7 +185,9 @@ class IntercomTest extends \PHPUnit_Framework_TestCase
     {
         $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
 
-        $postResponse->shouldReceive('getBody')->andReturn('{"type":"error.list","request_id":"anvt4on87prigma30i8g","errors":[{"code":"server_error","message":"Server Error"}]}');
+        $errorBody = '{"type":"error.list","request_id":"anvt4on87prigma30i8g","errors":[{"code":"server_error","message":"Server Error"}]}';
+
+        $postResponse->shouldReceive('getBody')->andReturn($errorBody);
         $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
         $postResponse->shouldReceive('getStatusCode')->andReturn(401);
 
@@ -194,7 +196,7 @@ class IntercomTest extends \PHPUnit_Framework_TestCase
             ->times(1)
             ->andReturn($postResponse);
         $this->provider->setHttpClient($client);
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
     }
 
     /**
@@ -204,7 +206,9 @@ class IntercomTest extends \PHPUnit_Framework_TestCase
     {
         $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
 
-        $postResponse->shouldReceive('getBody')->andReturn('');
+        $errorBody = '{"type":"error.list","request_id":"anvt4on87prigma30i8g","errors":[{"code":"server_error","message":"Server Error"}]}';
+
+        $postResponse->shouldReceive('getBody')->andReturn($errorBody);
         $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
         $postResponse->shouldReceive('getReasonPhrase')->andReturn('Internal Server Error');
         $postResponse->shouldReceive('getStatusCode')->andReturn(500);
@@ -214,6 +218,6 @@ class IntercomTest extends \PHPUnit_Framework_TestCase
             ->times(1)
             ->andReturn($postResponse);
         $this->provider->setHttpClient($client);
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
     }
 }


### PR DESCRIPTION
This pull request adds support for PHP 7.x and therefore fixes https://github.com/intercom/oauth2-intercom/issues/3

For that, we also need to upgrade the `league/oauth2-client` dependency to `~2.3`. The most important breaking changes that affect this library are:
* Version 2.0.0: Rename `getResponse()` to `getParsedResponse()`
* Version 2.3.0: Fix TypeError thrown because `getResourceOwner()` receives a non-JSON Response

These two changes needed to be adjusted in our code.

**This will be a major breaking change, and therefore a version 2.0.0 will need to be released.**

From our side, upgrade instructions:
* We're dropping support for PHP 5.5 (which went end of life ages ago)
* Upgrade `league/oauth2-client` to 2.3 or above
* Check the changelog by `league/oauth2-client` any change from there needs to be updated in any codebase using this library